### PR TITLE
Add Vue version of pricing form

### DIFF
--- a/vue/App.vue
+++ b/vue/App.vue
@@ -1,0 +1,14 @@
+<template>
+  <v-app>
+    <ConfigForm />
+  </v-app>
+</template>
+
+<script>
+import ConfigForm from './ConfigForm.vue'
+
+export default {
+  name: 'App',
+  components: { ConfigForm }
+}
+</script>

--- a/vue/ConfigForm.vue
+++ b/vue/ConfigForm.vue
@@ -1,0 +1,131 @@
+<template>
+  <v-container>
+    <v-form>
+      <v-row>
+        <v-col cols="12" sm="6">
+          <v-select
+            v-model="form.prodotto"
+            :items="prodotti"
+            label="Prodotto"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-text-field
+            v-model="form.lunghezza"
+            label="Lunghezza (mm)"
+            maxlength="4"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-select
+            v-model="form.motore_led"
+            :items="motoriLed"
+            label="Motore Led"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-select
+            v-model="form.colore_luce"
+            :items="coloriLuce"
+            label="Colore luce"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-select
+            v-model="form.tipo_schermo"
+            :items="tipiSchermo"
+            label="Schermo"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-select
+            v-model="form.sistema_fissaggio"
+            :items="sistemiFissaggio"
+            label="Sistema fissaggio"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-select
+            v-model="form.sistema_accensione"
+            :items="sistemiAccensione"
+            label="Sistema accensione"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-select
+            v-model="form.connettore_alimentazione"
+            :items="connettori"
+            label="Connettore alimentazione"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-text-field
+            v-model="form.lunghezza_cavo_alim"
+            label="Lunghezza cavo alimentazione"
+            maxlength="4"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-checkbox
+            v-model="form.giunzione_MF"
+            label="Giunzione M/F"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-select
+            v-model="form.uscita_cavo"
+            :items="usciteCavo"
+            label="Uscita Cavo"
+          />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-text-field
+            v-model="form.qta"
+            label="Quantità richiesta"
+            maxlength="3"
+          />
+        </v-col>
+        <v-col cols="12">
+          <v-btn color="primary" @click="submit">Determina prezzo</v-btn>
+        </v-col>
+      </v-row>
+    </v-form>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'ConfigForm',
+  data() {
+    return {
+      form: {
+        prodotto: '',
+        lunghezza: '',
+        motore_led: '',
+        colore_luce: '',
+        tipo_schermo: '',
+        sistema_fissaggio: '',
+        sistema_accensione: '',
+        connettore_alimentazione: '',
+        lunghezza_cavo_alim: '',
+        giunzione_MF: false,
+        uscita_cavo: '',
+        qta: ''
+      },
+      prodotti: [],
+      motoriLed: [],
+      coloriLuce: [],
+      tipiSchermo: [],
+      sistemiFissaggio: [],
+      sistemiAccensione: [],
+      connettori: [],
+      usciteCavo: []
+    }
+  },
+  methods: {
+    submit() {
+      // invio dati
+    }
+  }
+}
+</script>

--- a/vue/README.md
+++ b/vue/README.md
@@ -1,0 +1,9 @@
+# Vue Components
+
+This directory contains Vue components that reproduce the form used in
+`index.php` and `prezzi.php` using Vuetify.
+
+`ConfigForm.vue` mirrors the original fields (`prodotto`, `lunghezza`,
+`motore_led`, etc.) with Vuetify components such as `<v-form>`,
+`<v-text-field>` and `<v-select>`. `App.vue` shows how the form can be
+embedded in a Vuetify application.

--- a/vue/main.js
+++ b/vue/main.js
@@ -1,0 +1,7 @@
+import { createApp } from 'vue'
+import Vuetify from 'vuetify'
+import App from './App.vue'
+
+createApp(App)
+  .use(Vuetify)
+  .mount('#app')


### PR DESCRIPTION
## Summary
- create `ConfigForm.vue` replicating index form with Vuetify controls
- include an `App.vue` wrapper and simple `main.js`
- document the purpose of the new components

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm install` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686be1639ef4832489e4b37fa37152d1